### PR TITLE
Add password argument

### DIFF
--- a/steamctl/argparser.py
+++ b/steamctl/argparser.py
@@ -73,6 +73,7 @@ def generate_parser(pre=False):
 
     parser.add_argument('--anonymous', action='store_true', help='Anonymous Steam login')
     parser.add_argument('--user', type=str, help='Username for Steam login')
+    parser.add_argument('--password', type=str, help='Password for Steam login')
     parser.set_defaults(_cmd_func=print_help)
 
     if _subcommands:

--- a/steamctl/clients.py
+++ b/steamctl/clients.py
@@ -96,7 +96,10 @@ class CachingSteamClient(SteamClient):
             else:
                 self._LOG.info("Enter credentials for: %s", self.username)
 
-            password = getpass()
+            if args.password:
+                password = args.password
+            else:
+                password = getpass()
 
             # check for existing authenticator
             secrets_file = UserDataFile('authenticator/{}.json'.format(self.username))
@@ -109,6 +112,8 @@ class CachingSteamClient(SteamClient):
                     result = self.login(self.username, password, two_factor_code=sa.get_code())
 
                     if result == EResult.InvalidPassword:
+                        if args.password:
+                            return result
                         password = getpass("Invalid password for %s. Enter password: " % repr(self.username))
                         self.sleep(0.1)
 


### PR DESCRIPTION
fix #56

`--password` can be used to input password non-interactively together with `--user`.

However, if the account requires 2FA or email code, it will still prompt interactively.