### PR TITLE
Minor refurbishment

### DIFF
--- a/steamctl/clients.py
+++ b/steamctl/clients.py
@@ -138,7 +138,7 @@ class CachingSteamClient(SteamClient):
         if changefile.exists():
             try:
                 change_number = int(changefile.read_text())
-            except:
+            except Exception:
                 changefile.remove()
 
         self._LOG.debug("Checking PICS for app changes")
@@ -171,7 +171,11 @@ class CachingSteamClient(SteamClient):
         if cache_file.exists():
             return cache_file.read_json()
 
-    def get_product_info(self, apps=[], packages=[], *args, **kwargs):
+    def get_product_info(self, apps=None, packages=None, *args, **kwargs):
+        if apps is None:
+            apps = []
+        if packages is None:
+            packages = []
         resp = {'apps': {}, 'packages': {}}
 
         # if we have cached info for all apps, just serve from cache

--- a/steamctl/commands/apps/gcmds.py
+++ b/steamctl/commands/apps/gcmds.py
@@ -244,7 +244,7 @@ def cmd_apps_licenses_add(args):
                 try:
                     error = EPurchaseResultDetail(resp.json()['purchaseresultdetail'])
                     LOG.error(f'Result: {error!r}')
-                except:
+                except Exception:
                     LOG.error(f'Request failed with HTTP {resp.status_code}')
                 continue
 
@@ -273,7 +273,7 @@ def cmd_apps_licenses_remove(args):
 
             info = s.get_product_info(packages=[pkg_id])['packages'][pkg_id]
 
-            resp = web.post(f'https://store.steampowered.com/account/removelicense',
+            resp = web.post('https://store.steampowered.com/account/removelicense',
                             data={'packageid': pkg_id, 'sessionid': web.cookies.get('sessionid', domain='store.steampowered.com')},
                             )
 

--- a/steamctl/commands/depot/gcmds.py
+++ b/steamctl/commands/depot/gcmds.py
@@ -74,7 +74,7 @@ class ManifestFileIndex(object):
                 self._path_cache[filepath] = (manifest, filematch.file_mapping)
 
     def file_exists(self, path):
-        return self._locate_file_mapping(path) != None
+        return self._locate_file_mapping(path) is not None
 
     def get_file(self, path, *args, **kwargs):
         ref = self._locate_file_mapping(path)

--- a/steamctl/commands/depot/gcmds.py
+++ b/steamctl/commands/depot/gcmds.py
@@ -278,7 +278,7 @@ def cmd_depot_info(args):
             for i, manifest in enumerate(manifests, 1):
                 print("App ID:", manifest.app_id)
                 print("Depot ID:", manifest.metadata.depot_id)
-                print("Depot Name:", manifest.name if manifest.name else 'Unnamed Depot')
+                print("Depot Name:", manifest.name or 'Unnamed Depot')
                 print("Manifest GID:", manifest.metadata.gid_manifest)
                 print("Created On:", fmt_datetime(manifest.metadata.creation_time))
                 print("Size:", fmt_size(manifest.metadata.cb_disk_original))

--- a/steamctl/commands/webapi/cmds.py
+++ b/steamctl/commands/webapi/cmds.py
@@ -48,7 +48,7 @@ def cmd_webapi_list(args):
     if args.format != 'text':
         if args.format == 'json':
             json.dump(json.loads(resp), sys.stdout, indent=4, sort_keys=True)
-            print('')
+            print()
         else:
             print(resp)
         return
@@ -82,7 +82,7 @@ def cmd_webapi_list(args):
                         ('- ' + param['description']) if 'description' in param else '',
                         ))
 
-                print('')
+                print()
 
 def cmd_webapi_call(args):
     # load key=value pairs. Stuff thats start with [ is a list, so parse as json
@@ -141,6 +141,6 @@ def cmd_webapi_call(args):
     # by default we print json, other formats are shown as returned from api
     if args.format == 'json':
         json.dump(json.loads(resp.rstrip('\n\t\x00 ')), sys.stdout, indent=4, sort_keys=True)
-        print('')
+        print()
     else:
         print(resp)

--- a/steamctl/utils/prompt.py
+++ b/steamctl/utils/prompt.py
@@ -6,8 +6,8 @@ def pmt_confirmation(text, default_yes=None):
     while True:
         response = input("{} [{}/{}]: ".format(
             text,
-            'YES' if default_yes == True else 'yes',
-            'NO' if default_yes == False else 'no',
+            'YES' if default_yes else 'yes',
+            'NO' if default_yes is False else 'no',
             )).strip()
 
         if not response:

--- a/steamctl/utils/storage.py
+++ b/steamctl/utils/storage.py
@@ -54,7 +54,7 @@ class FileBase(object):
     def mkdir(self):
         ensure_dir(self.path, 0o700)
 
-    def older_than(seconds=0, minutes=0, hours=0, days=0):
+    def older_than(self, seconds=0, minutes=0, hours=0, days=0):
         delta = seconds + (minutes*60) + (hours*3600) + (days*86400)
         ts = os.path.getmtime(self.path)
         return ts + delta > time()


### PR DESCRIPTION
```
steamctl/clients.py:141:13: B001 Do not use bare `except:`, it also catches unexpected events like
memory errors, interrupts, system exit, and so on. Prefer `except Exception:`. 
If you're sure what you're doing, be explicit and write `except BaseException:`.
```
```
steamctl/clients.py:174:37: B006 Do not use mutable data structures for argument defaults. 
They are created during function definition time.
All calls to the function reuse this one instance of that data structure, persisting changes between them.
```

```
steamctl/commands/apps/gcmds.py:247:17: B001 Do not use bare `except:`, it also catches unexpected events like
memory errors, interrupts, system exit, and so on. Prefer `except Exception:`. 
If you're sure what you're doing, be explicit and write `except BaseException:`.
```
```
steamctl/commands/apps/gcmds.py:276:29: F541 f-string is missing placeholders
```

```
steamctl/commands/depot/gcmds.py:77:48: E711 comparison to None should be 'if cond is not None:'
```

```
steamctl/utils/prompt.py:9:34: E712 comparison to True should be 'if cond is True:' or 'if cond:'
```
```
steamctl/utils/prompt.py:10:33: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
```

```
steamctl/utils/storage.py:57:20: B902 Invalid first argument 'seconds' used for instance method.
Use the canonical first argument name in methods, i.e. self.
```

---

```
steamctl\commands\depot\gcmds.py:281:38 [FURB110]: Replace `x if x else y` with `x or y`
```

Sometimes ternary (aka, inline if statements) can be simplified to a single `or` expression.

Bad:

```
z = x if x else y
```

Good:

```
z = x or y
```

Note: if `x` depends on side-effects, then this check should be ignored.

```
steamctl\commands\webapi\cmds.py:51:13 [FURB105]: Replace `print("")` with `print()`
steamctl\commands\webapi\cmds.py:85:17 [FURB105]: Replace `print("")` with `print()`
steamctl\commands\webapi\cmds.py:144:9 [FURB105]: Replace `print("")` with `print()`
```

`print("")` can be simplified to just `print()`.