### PR TITLE
rename webapi command --version to --apiver to avoid conflict

### DIFF
--- a/steamctl/commands/webapi/__init__.py
+++ b/steamctl/commands/webapi/__init__.py
@@ -97,7 +97,7 @@ def cmd_parser(cp):
                           help='Output format')
     scp_call.add_argument('--method', choices=['GET', 'POST'], type=str,
                           help='HTTP method to use')
-    scp_call.add_argument('--version', type=int,
+    scp_call.add_argument('--apiver', type=int,
                           help='Method version')
     scp_call.add_argument('endpoint', type=str,
                           help='WebAPI endpoint name (eg ISteamWebAPIUtil.GetSupportedAPIList)')\

--- a/steamctl/commands/webapi/cmds.py
+++ b/steamctl/commands/webapi/cmds.py
@@ -93,7 +93,7 @@ def cmd_webapi_call(args):
         return 1  # error
 
     apicall = webapi.get
-    version = args.version or 1
+    version = args.apiver or 1
 
     if args.method == 'POST':
         apicall = webapi.post
@@ -115,7 +115,7 @@ def cmd_webapi_call(args):
         if args.method is None:
             if webapi_map[args.endpoint][0] == 'POST':
                 apicall = webapi.post
-        if args.version is None:
+        if args.apiver is None:
             version = webapi_map[args.endpoint][1]
 
     # drop reserved words. these have special meaning for steam.webapi


### PR DESCRIPTION
currently it is impossible to use webapi call on anything but version 1 apis, since the argument parser always interprets a --version parameter wherever you pass it in the command line as a request to print the version number of steamctl