### PR TITLE
Update enums.py for unknown payments

### DIFF
--- a/steamctl/commands/apps/enums.py
+++ b/steamctl/commands/apps/enums.py
@@ -94,6 +94,7 @@ class EPaymentMethod(SteamIntEnum):
     OEMTicket = 256
     Split = 512
     Complimentary = 1024
+    Unknown = 1025
 
 class EPackageStatus(SteamIntEnum):
     Available = 0


### PR DESCRIPTION
without it we get an error 
Traceback (most recent call last):
  File "/home/user/steam_cleaner/venv/bin/steamctl", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/user/steam_cleaner/venv/lib/python3.13/site-packages/steamctl/__main__.py", line 59, in main
    rcode = cmd_func(args=args)
  File "/home/user/steam_cleaner/venv/lib/python3.13/site-packages/steamctl/commands/apps/gcmds.py", line 204, in cmd_apps_licenses_list
    print(f"  Payment method:   { EPaymentMethod(license.payment_method).name } ({license.payment_method})")
                                  ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/enum.py", line 726, in __call__
    return cls.__new__(cls, value)
           ~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/lib/python3.13/enum.py", line 1201, in __new__
    raise ve_exc
ValueError: 1025 is not a valid EPaymentMethod
